### PR TITLE
Add Google Tag Manager

### DIFF
--- a/app/views/layouts/_google.html.haml
+++ b/app/views/layouts/_google.html.haml
@@ -1,11 +1,8 @@
-/ Google Analytics
+%noscript
+  %iframe{:height => "0", :src => "//www.googletagmanager.com/ns.html?id=GTM-NGNVM5", :style => "display:none;visibility:hidden", :width => "0"}
 :javascript
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-52835586-1', 'auto');
-  ga('require', 'displayfeatures');
-  ga('send', 'pageview');
-/ End Google Analytics
+  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-NGNVM5');

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -13,8 +13,8 @@
     = csrf_meta_tag
     / HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries
     /[if lt IE 9]
-    = render partial: 'layouts/google'
   %body
+    = render partial: 'layouts/google'
     .container
       .middle-wrap
         .middle-cell

--- a/app/views/layouts/presentation.html.haml
+++ b/app/views/layouts/presentation.html.haml
@@ -12,9 +12,9 @@
     = csrf_meta_tag
     / HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries
     /[if lt IE 9]
-    = render partial: 'layouts/google' if Rails.env.production?
 
   %body#home.body.js-body-action
+    = render partial: 'layouts/google' if Rails.env.production?
     %header.header.omni-video__overlay
       = render partial: 'layouts/presentation/header'
 


### PR DESCRIPTION
Replaced the google analytics tag with the google tag manager. Google analytics will be inserted by the GTM script after we do the deploy.

Moved the script right at the start of the body: https://developers.google.com/tag-manager/quickstart
